### PR TITLE
make sure current code is not crashing even when compiled with

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ start-mssql:
 test-mssql:
 	go test -v -mssrv=localhost -msdb=$(DB_NAME) -msuser=sa -mspass=$(MSSQL_SA_PASSWORD) -run=TestMSSQL
 
+test-mssql-race:
+	go test -v -mssrv=localhost -msdb=$(DB_NAME) -msuser=sa -mspass=$(MSSQL_SA_PASSWORD) -run=TestMSSQL --race
+
 stop-mssql:
 	docker stop $(MSSQL_CONTAINER_NAME)
 	docker rm $(MSSQL_CONTAINER_NAME)

--- a/column.go
+++ b/column.go
@@ -141,7 +141,7 @@ func (c *BaseColumn) Value(buf []byte) (driver.Value, error) {
 		if p == nil {
 			return buf, nil
 		}
-		s := (*[1 << 28]uint16)(p)[:len(buf)/2]
+		s := (*[1 << 28]uint16)(p)[: len(buf)/2 : len(buf)/2]
 		return utf16toutf8(s), nil
 	case api.SQL_C_TYPE_TIMESTAMP:
 		t := (*api.SQL_TIMESTAMP_STRUCT)(p)


### PR DESCRIPTION
-gcflags=all=-d=checkptr

flag (see https://golang.org/issues/34964 for details).

Verified with

go test ... --race

on both Windows and Linux.

Fixes #144